### PR TITLE
Pets: Bugfixes and add Prof. Bonus filter / display cells

### DIFF
--- a/Components/Pet/PetPriceCell.jsx
+++ b/Components/Pet/PetPriceCell.jsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { FixSalePrice } from "../../Logic/HeroBase"
 import Image from "next/image"
 import Jewel from "../../public/Jewel.png"
 import Jade from "../../public/Jade.png"
@@ -22,7 +21,7 @@ export default function PetPriceCell({ children }) {
         >
           <Grid container justifyContent={"space-between"}>
             <Grid item sx={{ alignSelf: "center" }}>
-              {FixSalePrice(children.salePrice)}
+              {children.salePrice}
             </Grid>
             <Grid item sx={{ marginTop: "4px" }}>
               {children.currentRealm == "SER2" ? (

--- a/Components/PetFilters.jsx
+++ b/Components/PetFilters.jsx
@@ -18,7 +18,8 @@ import SelectItem from "./Filters/SelectItem"
 import {
   PetBackgrounds,
   PetEggTypes,
-  PetElements
+  PetElements,
+  PetProfessionBonusNames
 } from "../Logic/PetDropdownOptions"
 import NumberSlider from "./Filters/NumberSlider"
 import Pet03StarSlider from "./PetFilters/Pet03StarSlider"
@@ -41,6 +42,8 @@ export default function PetFilters({
   const setCraftBonus = useStore((state) => state.setCraftBonus)
   const profBonus = useStore((state) => state.profBonus)
   const setProfBonus = useStore((state) => state.setProfBonus)
+  const profBonusName = useStore((state) => state.profBonusName)
+  const setProfBonusName = useStore((state) => state.setProfBonusName)
   const rarity = useStore((state) => state.rarity)
   const setRarity = useStore((state) => state.setRarity)
   const idInput = useStore((state) => state.idInput)
@@ -108,7 +111,7 @@ export default function PetFilters({
         if (values != ``) {
           values += `,`
         }
-        values += bonusMap[i].join(", ")
+        values += bonusMap[i].join(",")
       }
     }
     return values
@@ -163,8 +166,36 @@ export default function PetFilters({
       })
       filters += `],`
     }
+    let profBonusFilter = []
+    let profBonusFilter1 = ``
+    let profBonusFilter2 = ``
     if (profBonus[0] > 1 || profBonus[1] < 3) {
-      filters += `profBonus_in:[${GetBonusValues(profBonus[0], profBonus[1])}],`
+      profBonusFilter1 = GetBonusValues(profBonus[0], profBonus[1])
+    }
+    if (profBonusName.length > 0) {
+      profBonusName.forEach((c, i) => {
+        profBonusFilter2 += `${c.value}`
+        if (i < profBonusName.length - 1) {
+          profBonusFilter2 += `,`
+        }
+      })
+    }
+    if ((profBonusFilter1.length > 0) && (profBonusFilter2.length > 0)) {
+      // Merge where both values exist
+      profBonusFilter = profBonusFilter1.split(",").filter(v => profBonusFilter2.split(",").indexOf(v) > -1)
+      // if none match set to an empty query
+      if (profBonusFilter.length == 0) {
+        profBonusFilter = [ 0 ]
+      }
+    }
+    else if (profBonusFilter1.length > 0) {
+      profBonusFilter = profBonusFilter1.split(",")
+    }
+    else if (profBonusFilter2.length > 0) {
+      profBonusFilter = profBonusFilter2.split(",")
+    }
+    if (profBonusFilter.length > 0) {
+      filters += `profBonus_in:[${profBonusFilter.join(",")}],`
     }
     if (craftBonus[0] > 0 || craftBonus[1] < 3) {
       filters += `craftBonus_in:[${GetBonusValues(craftBonus[0], craftBonus[1])}],`
@@ -271,6 +302,13 @@ export default function PetFilters({
               setValues={setBackground}
             >
               {PetBackgrounds}
+            </SelectItem>
+            <SelectItem
+              title={"Prof. Bonus Name"}
+              values={profBonusName}
+              setValues={setProfBonusName}
+            >
+              {PetProfessionBonusNames}
             </SelectItem>
             <PetRaritySlider
               setRarity={setRarity}

--- a/Logic/PetBase.js
+++ b/Logic/PetBase.js
@@ -1,6 +1,7 @@
 import { blueEggData } from "./blueEggData"
 import { greyEggData } from "./greyEggData"
 import { greenEggData } from "./greenEggData"
+import { PetProfessionBonusNames } from "./PetDropdownOptions"
 import { FixSalePrice } from "./HeroBase"
 export const backgrounds = {
   0: "Stillwood Meadow",
@@ -76,6 +77,8 @@ const initiatePet = (pet) => {
       pet.elementName = "dark"
       break
   }
+  pet.profBonusName = PetProfessionBonusNames
+    .find(bonus => bonus.value.split(",").some(value => value == pet.profBonus))?.label ?? 'Unknown Bonus'
   return true
 }
 

--- a/Logic/PetBase.js
+++ b/Logic/PetBase.js
@@ -1,6 +1,7 @@
 import { blueEggData } from "./blueEggData"
 import { greyEggData } from "./greyEggData"
 import { greenEggData } from "./greenEggData"
+import { FixSalePrice } from "./HeroBase"
 export const backgrounds = {
   0: "Stillwood Meadow",
   1: "Forest Trail",
@@ -38,6 +39,7 @@ const initiatePet = (pet) => {
     console.log("NULL PET", pet)
     return false
   }
+  pet.salePrice = Number(FixSalePrice(pet.salePrice))
   pet.season = data.season
   pet.appearanceRarity = data.rarity
   pet.family = data.family

--- a/Logic/PetDropdownOptions.js
+++ b/Logic/PetDropdownOptions.js
@@ -39,3 +39,29 @@ export const PetEggTypes = [
     label: <Image src={GreenEgg} layout={"fixed"} width={20} height={20} />
   }
 ]
+export const PetProfessionBonusNames = [
+  { value: "1,80,160,10001,10080,10160,20001,20080,20160", label: "Unrevealed" },
+  { value: "2,81,161", label: "Efficient Angler" },
+  { value: "3,82,162", label: "Bountiful Catch" },
+  { value: "4,83,163,10004,10083,10163", label: "Keen Eye" },
+  { value: "5,84,164,10005,10084,10164", label: "Fortune Seeker" },
+  { value: "6,85,165,10006,10085,10165,20005,20084,20164", label: "Clutch Collector" },
+  { value: "7,86,166,10007,10086,10166,20006,20085,20165", label: "Runic Discoveries" },
+  { value: "8,87,167", label: "Skilled Angler" },
+  { value: "9,88,168", label: "Astute Angler" },
+  { value: "10,89,169,10010,10089,10169,20009,20088,20168", label: "Bonus Bounty" },
+  { value: "11,90,170,10011,10090,10170,20010,20089,20169", label: "Gaia's Chosen" },
+  { value: "171", label: "Innate Angler" },
+  { value: "10002,10081,10061", label: "Efficient Scavenger" },
+  { value: "10003,10082,10162", label: "Bountiful Haul" },
+  { value: "10008,10087,10167", label: "Skilled Scavenger" },
+  { value: "10009,10088,10168", label: "Astute Scavenger" },
+  { value: "10171", label: "Innate Scavenger" },
+  { value: "20002,20081,20161", label: "Efficient Greenskeeper" },
+  { value: "20003,20082,20162", label: "Bountiful Harvest" },
+  { value: "20004,20083,20163", label: "Second Chance" },
+  { value: "20007,20086,20166", label: "Skilled Greenskeeper" },
+  { value: "20008,20087,20167", label: "Astute Greenskeeper" },
+  { value: "20090,20170", label: "Power Surge" },
+  { value: "20171", label: "Innate Greenskeeper" }
+]

--- a/Logic/PetTableColumns.js
+++ b/Logic/PetTableColumns.js
@@ -10,8 +10,8 @@ import ProfessionBonus from "../Components/Pet/ProfessionBonus"
 
 const GetBonusStars = (bonusValue) => {
   let stars = 0
-  /* drop extra bits above 0xFF (255) */
-  let adjBonus = bonusValue & 0xFF;
+  /* drop values above 1000 */
+  let adjBonus = bonusValue % 1000;
   if (adjBonus > 0) {
     if (adjBonus < 80)
       stars = 1

--- a/Logic/PetTableColumns.js
+++ b/Logic/PetTableColumns.js
@@ -112,6 +112,16 @@ let petColumnDefs = [
     }
   },
   {
+    headerName: "Prof. Bonus Name",
+    field: "profBonusName",
+    hide: false,
+  },
+  {
+    headerName: "Prof. Bonus Value",
+    field: "profBonusScalar",
+    hide: false,
+  },
+  {
     headerName: "Crafting ⭐",
     field: "craftBonus",
     type: "number",

--- a/Store/PetsBase/PetsBaseFilterStore.js
+++ b/Store/PetsBase/PetsBaseFilterStore.js
@@ -5,6 +5,7 @@ const initialState = {
   combatBonus: [0, 3],
   craftBonus: [0, 3],
   profBonus: [1, 3],
+  profBonusName: [],
   rarity: [0, 4],
   idInput: ``,
   eggType: [],
@@ -60,6 +61,12 @@ const PetsBaseFilterStore = (set) => ({
   setProfBonus: (profBonus) => {
     set({
       profBonus
+    })
+  },
+  profBonusName: [],
+  setProfBonusName: (profBonusName) => {
+    set({
+      profBonusName
     })
   },
   rarity: [0, 4],


### PR DESCRIPTION
This PR has a few bugfixes for the pets search:
- salePrice was incorrectly formatted when exporting to CSV
- The calculation in GetBonusStars used to mask off values above 255 was incorrect

It also adds the Profession Bonus Name / Scalar values to the filter and display cells.

I use this all the time to look for certain pet types on the market.

Comments / feedback welcomed.