### PR TITLE
hero-filters: fix clear filters state for network

### DIFF
--- a/Store/HeroBase/HeroBaseFilterStore.js
+++ b/Store/HeroBase/HeroBaseFilterStore.js
@@ -21,7 +21,7 @@ const initialState = {
   passive1: [],
   passive2: [],
   background: [],
-  realm: [{ value: "", label: "Any" }],
+  realm: [],
   gender: [],
   minStrength: 0,
   minDexterity: 0,


### PR DESCRIPTION
- When the "Clear Filters" button is used, it sets the network caption to "Any" with an empty value breaking the filter.  This was due to the previous multi-select change. Correct this by setting the select to an empty array like the other multi-select dropdowns.